### PR TITLE
Updating manifest to latest kernel/libraries

### DIFF
--- a/master.xml
+++ b/master.xml
@@ -31,6 +31,6 @@
     <linkfile dest="easy-settings.cmake" src="easy-settings.cmake"/>
     <linkfile dest="settings.cmake" src="settings.cmake"/>
   </project>
-  <project name="util_libs.git" path="projects/util_libs" revision="8ed42ff66c586ab2b6dc32f678e00764453754f0" upstream="master"/>
+  <project name="util_libs.git" path="projects/util_libs" revision="5df1034155667093a5e7a435b621067013ed8c26" upstream="master"/>
   <project name="opensbi" remote="opensbi" revision="a98258d0b537a295f517bbc8d813007336731fa9" path="tools/opensbi"/>
 </manifest>

--- a/master.xml
+++ b/master.xml
@@ -21,7 +21,7 @@
   <project name="riscv-pk" path="tools/riscv-pk" remote="seL4" revision="riscv_he_v0.6"/>
   <project name="seL4.git" path="kernel" remote="seL4" revision="riscv_he_v0.6" upstream="riscv_he_v0.6"/>
   <project name="seL4_libs.git" path="projects/seL4_libs" revision="riscv_hyp" upstream="riscv_hyp"/>
-  <project name="seL4_tools.git" path="tools/seL4" revision="148f5241d3395750d97a3f53371e9a9c4cfd357e" upstream="master">
+  <project name="seL4_tools.git" path="tools/seL4" revision="3234b1fb94dea6525e3ba3df205a453baf63c1ae" upstream="master">
     <linkfile dest="CMakeLists.txt" src="cmake-tool/default-CMakeLists.txt"/>
     <linkfile dest="init-build.sh" src="cmake-tool/init-build.sh"/>
     <linkfile dest="griddle" src="cmake-tool/griddle"/>

--- a/master.xml
+++ b/master.xml
@@ -26,7 +26,7 @@
     <linkfile dest="init-build.sh" src="cmake-tool/init-build.sh"/>
     <linkfile dest="griddle" src="cmake-tool/griddle"/>
   </project>
-  <project name="sel4runtime.git" path="projects/sel4runtime" remote="sel4proj" revision="ec3c1348c31ce2c459f9a80a1c79f2237de3a4cd" upstream="master"/>
+  <project name="sel4runtime.git" path="projects/sel4runtime" remote="sel4proj" revision="d935dd05da0cf959e9fd0140af913dc6fdaa0221" upstream="master"/>
   <project name="sel4_riscv_vmm.git" path="projects/sel4_riscv_vmm" remote="sel4proj" upstream="master">
     <linkfile dest="easy-settings.cmake" src="easy-settings.cmake"/>
     <linkfile dest="settings.cmake" src="settings.cmake"/>

--- a/master.xml
+++ b/master.xml
@@ -17,7 +17,7 @@
   
   <default remote="seL4" revision="master"/>
   
-  <project name="musllibc.git" path="projects/musllibc" remote="seL4" revision="4a8335b2248d934e2e40386af4f1b0495b3c173d" upstream="sel4"/>
+  <project name="musllibc.git" path="projects/musllibc" remote="seL4" revision="3d6b939e8f05cb1d2a1a8c8166609bf2e652e975" upstream="sel4"/>
   <project name="riscv-pk" path="tools/riscv-pk" remote="seL4" revision="riscv_he_v0.6"/>
   <project name="seL4.git" path="kernel" remote="seL4" revision="riscv_he_v0.6" upstream="riscv_he_v0.6"/>
   <project name="seL4_libs.git" path="projects/seL4_libs" revision="riscv_hyp" upstream="riscv_hyp"/>


### PR DESCRIPTION
This aims to get the VMM using the latest kernel/libraries.

I have rebased master onto the branches on seL4_libs and seL4. For seL4 I had to add a commit to fix the rebase for now, I'll fix up the original commits instead when/if the changes attempt to be merged into the mainline kernel.

To test the changes, you should be able to do:
`repo init -u https://github.com/Ivan-Velickovic/sel4-riscv-vmm-manifest.git -b testing -m master.xml`
to try out the changes.

I've tested the single core and multi core VMM, both boot Linux successfully.

I have added a new README that aims to contain all the instructions needed just for the current version of the VMM, so you don't have to piece the different parts of the current README together in order to get it building and running. If you want me to add the README as a separate update rather than overwriting everything else that exists, I can do that.